### PR TITLE
文章の読み込み遅延をなくす

### DIFF
--- a/app/controllers/api/books_controller.rb
+++ b/app/controllers/api/books_controller.rb
@@ -10,8 +10,12 @@ class Api::BooksController < ApplicationController
   def show
     @book = Book.find_by(id: params[:id])
     File.open("db/txt/#{@book.txt_file}", 'r') do |f|
+      sentence = f.read
       natto = Natto::MeCab.new
-      @words = natto.enum_parse(f.read)
+      page = params[:page].to_i
+      pre_sentence = 800 * (page - 1)
+      sentence.slice!(0..pre_sentence-1) if pre_sentence > 0
+      @words = natto.enum_parse(sentence.truncate(800, omission: ''))
     end
   rescue StandardError => e
     logger.warn(e.inspect)

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -3,7 +3,6 @@
 class BooksController < ApplicationController
   def index
     @books = Book.efficiency_list.recent(30)
-    # binding.pry
     @rankings = Book.where(id: Ranking.order(rank: :asc).limit(10).select(:book_id)).includes(:author, :rakuten_book_info)
   end
 

--- a/app/javascript/packs/components/sokudoku.vue
+++ b/app/javascript/packs/components/sokudoku.vue
@@ -19,6 +19,7 @@
       <p>
         <span v-for="(word, idx) in words" :class="{'currentText': idx == currentNum }">{{word.text}}</span>
       </p>
+      <p @click="moreSentence" id="sentence-more-read">もっと読み込む</p>
     </div>
   </div>
 </template>
@@ -36,6 +37,7 @@ export default {
     return {
       words: [],
       title: '',
+      page: 1,
       currentNum: 0,
       currentWord: '',
       reading: false,
@@ -56,6 +58,9 @@ export default {
       if(this.currentNum % 10 == 0){
         this.getCurrentTextPosition()
       }
+      if(this.currentNum >= this.words.length - 50){
+        this.moreSentence()
+      }
     },
     currentTextPosition: function(){
       if(this.currentTextPosition < 200 ){
@@ -65,10 +70,19 @@ export default {
   },
   methods: {
     fetchWords: function () {
-      axios.get(`/api/books/${this.$route.params.id}`).then((response) => {
+      axios.get(`/api/books/${this.$route.params.id}?page=${this.page}`).then((response) => {
         this.title = response.data.title
         this.words = response.data.words
         this.currentWord = this.title
+        this.page++
+      }, (error) => {
+        console.log(error);
+      });
+    },
+    moreSentence: function(){
+      axios.get(`/api/books/${this.$route.params.id}?page=${this.page}`).then((response) => {
+        this.words.push(...response.data.words)
+        this.page++
       }, (error) => {
         console.log(error);
       });
@@ -179,5 +193,9 @@ input[type=range]::-webkit-slider-thumb{
   height: 450px;
   z-index: 5;
 }
-
+#sentence-more-read{
+  z-index: 9;
+  position: relative;
+  color: #777777;
+}
 </style>

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -10,7 +10,6 @@ section.section
       = link_to ranking_path do
         | もっと見る
         i.fas.fa-chevron-right
-= link_to 'ログイン', new_user_session_path
 #books
   books
 = javascript_pack_tag "books"


### PR DESCRIPTION
## Suumary(追加/変更したこと)
- 文字の読み込みを800文字に変更
- 読み切る50単語前に、次の800文字を取得するAPIを走らせる

### Issue
close #37 
