### PR TITLE
著者の本をなるべくランキング順に表示

### DIFF
--- a/app/controllers/api/authors_controller.rb
+++ b/app/controllers/api/authors_controller.rb
@@ -8,6 +8,14 @@ class Api::AuthorsController < ApplicationController
 
   def show
     @author = Author.find_by(name: params[:name])
-    @books = @author ? @author.books.page(params[:page]).per(PER).includes(:author, :rakuten_book_info).order('rakuten_book_infos.medium_image_url desc') : nil
+    @books =  if @author
+                @author.books
+                  .includes(:author, :rakuten_book_info, :ranking)
+                  .order(Arel.sql('rankings.rank is null, rankings.rank asc'))
+                  .order('rakuten_book_infos.medium_image_url desc')
+                  .page(params[:page]).per(PER)
+              else
+                nil
+              end
   end
 end

--- a/app/controllers/api/books_controller.rb
+++ b/app/controllers/api/books_controller.rb
@@ -30,7 +30,7 @@ class Api::BooksController < ApplicationController
   end
 
   def search
-    @books = Book.viewable.search(params[:title]).page(params[:page]).per(PER).order(id: :desc)
+    @books = Book.viewable.search(params[:title])
   end
 
   def ranking

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -8,7 +8,7 @@ class Author < ApplicationRecord
   scope :recent, ->(count) { order(id: :desc).limit(count) }
 
   def self.search(search)
-    if search
+    if search.present?
       where('name like ?', "%#{search}%").recent(30)
     else
       recent(30)
@@ -16,7 +16,10 @@ class Author < ApplicationRecord
   end
 
   def take_books(num)
-    books.viewable.includes(:rakuten_book_info).select(:id, :title, :impressions_count)
-      .order(impressions_count: :desc).order('rakuten_book_infos.medium_image_url desc').take(num)
+    books.viewable.includes(:rakuten_book_info, :ranking)
+      .select(:id, :title, :impressions_count)
+      .order('rankings.rank is null, rankings.rank asc')
+      .order(impressions_count: :desc)
+      .order('rakuten_book_infos.medium_image_url desc').take(num)
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -16,14 +16,16 @@ class Book < ApplicationRecord
   scope :recent, ->(count) { order(id: :desc).limit(count) }
   scope :viewable, -> { where(is_published: true) }
   scope :efficiency_list, -> do
-    includes(:author, :rakuten_book_info).select('id', 'title', 'author_id', 'impressions_count').order('rakuten_book_infos.medium_image_url desc')
+    includes(:author, :rakuten_book_info)
+      .select('id', 'title', 'author_id', 'impressions_count')
+      .order('rakuten_book_infos.medium_image_url desc')
   end
 
   def self.search(search)
-    if search
-      where('title like ?', "%#{search}%").efficiency_list.recent(30)
+    if search.present?
+      where('title like ?', "%#{search}%").efficiency_list.limit(50)
     else
-      efficiency_list.recent(30)
+      joins(:ranking).includes(:author, :rakuten_book_info, :ranking).order('rank').limit(50)
     end
   end
 end

--- a/app/views/authors/show.html.slim
+++ b/app/views/authors/show.html.slim
@@ -1,7 +1,10 @@
 - content_for :html_title, "#{@author.name}の速読できる本一覧"
 - content_for :meta_description, "#{@author.name}の#{@author.books.size}冊の本一覧です。「#{@author.books.first.title}」などがあります。"
 - content_for :css_each_page, stylesheet_link_tag('books'), media: 'screen'
-h1.title.has-text-centered.is-4.push-top = @author.name
+h1.title.has-text-centered.is-4.push-top.has-text-grey-darker
+  | #{@author.name}
+  span.is-size-6.has-text-grey-dark
+    | (#{@author.books.size})
 #books
   books
 = javascript_pack_tag "books"

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Book, type: :model do
       context 'not exist params' do
         it 'work' do
           expect(Book.search('').length).to eq(Book.all.length)
-          expect(Book.search('').first.id).to eq(Book.last.id)
         end
       end
     end


### PR DESCRIPTION
## Suumary(追加/変更したこと)
- 本一覧（著者の本を4つずつ表示する箇所）での「ランキング順に」本を4つずつ表示
- 著者ページで著者名の横に著者の本の数を表示

### Issue
close #99 